### PR TITLE
(example) Explicitly patch tendermint-rs for namada v0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9" }
+tendermint-proto = "0.23.5"
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }
@@ -23,6 +23,9 @@ tracing-tower = { git = "https://github.com/tokio-rs/tracing/", tag = "tracing-0
 [dev-dependencies]
 structopt = "0.3"
 tracing-subscriber = { git = "https://github.com/tokio-rs/tracing/", tag = "tracing-0.1.30" }
+
+[patch.crates-io]
+tendermint-proto = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9" }
 
 [features]
 doc = []


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/527