### PR TITLE
Use tendermint-rs version as used in namada v0.10.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,19 @@
+on: [push, pull_request]
+
+name: Rust CI
+
+jobs:
+  test:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = "0.23.5"
+tendermint-proto = { git = "https://github.com/heliaxdev/tendermint-rs?branch=ledger-main", rev = "e6c684731f21bffd89886d3e91074b96aee074ba" }
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }
@@ -23,10 +23,6 @@ tracing-tower = { git = "https://github.com/tokio-rs/tracing/", tag = "tracing-0
 [dev-dependencies]
 structopt = "0.3"
 tracing-subscriber = { git = "https://github.com/tokio-rs/tracing/", tag = "tracing-0.1.30" }
-
-[patch.crates-io]
-# patched to a commit on the `eth-bridge-integration` branch of our fork
-tendermint-proto = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "bc0b6ac47b3bfc1ee8b944341b654b867b3b5d0b" }
 
 [features]
 doc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = { git = "https://github.com/heliaxdev/tendermint-rs?branch=ledger-main", rev = "e6c684731f21bffd89886d3e91074b96aee074ba" }
+tendermint-proto = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba" }
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }


### PR DESCRIPTION
Also adapt a simple `cargo check` CI job from upstream, to check things actually build.