### PR TITLE
Update to latest tendermint-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba" }
+tendermint-proto = { git = "https://github.com/heliaxdev/tendermint-rs", rev = "9694eaa42799eec2af2af06a15c7cd779f48fb9c" }
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/825

Adapting https://github.com/heliaxdev/tower-abci/pull/5